### PR TITLE
InstancedMeshes for arrows in LineV2 lines get added to new scenes after the initial

### DIFF
--- a/.changeset/plenty-avocados-shop.md
+++ b/.changeset/plenty-avocados-shop.md
@@ -1,0 +1,5 @@
+---
+"@crowdstrike/graphics-core": patch
+---
+
+InstancedMesh for Arrows in LineV2 get added to new scenes

--- a/package/src/objects/lines-v2/line-base.ts
+++ b/package/src/objects/lines-v2/line-base.ts
@@ -51,7 +51,6 @@ lineV2TextStyle.fontName = 'Helvetica Neue';
 lineV2TextStyle.pixelDensity = 2;
 
 export class LineV2 extends Line2 {
-  static isInstancedMeshAddedToScene = false;
 
   static ARROW_GEOMETRY?: THREE.CylinderGeometry;
   static TEXT_STYLE = lineV2TextStyle;
@@ -143,14 +142,23 @@ export class LineV2 extends Line2 {
     LineV2.arrows.mesh.geometry.computeBoundingBox();
   }
 
+  /**
+   * This method is called from the ThreeJSView class.
+   *
+   * Every time a new scene is created, the instanced meshes used for lines
+   * are also added.
+   */
   static addInstancedMeshesToScene(scene: THREE.Scene | ThreeJSView | THREE.Object3D) {
-    if (!LineV2.isInstancedMeshAddedToScene) {
       LineV2.labels.shouldDispatchMouseEvents = true;
-      scene.add(LineV2.labels.mesh);
-      scene.add(LineV2.arrows.mesh);
-    }
 
-    LineV2.isInstancedMeshAddedToScene = true;
+      /**
+       * addMeshToScene ensures that these meshes are only added once per scene.
+       */
+      LineV2.arrows.addMeshToScene(scene)
+      LineV2.labels.addMeshToScene(scene)
+
+      LineV2.arrows.mesh.position.z = 0;
+      LineV2.labels.mesh.position.z = 0;
   }
 
   constructor(settings: LineV2Settings) {


### PR DESCRIPTION
Previously, there was a static check to see whether an `InstancedMesh` for the line arrows (`LineV2`) should be added to the current `THREE.Scene` – `!LineV2.isInstancedMeshAddedToScene`. Once it was made true, new meshes would not be added. This fix utilizes the `addMeshToScene` method of `InstancedAttributes` to ensure that it is always added to new scenes.

### TEST PLAN
Go to the `/edge-types` demo, then go back to the index page, then visit it again, and the arrows should remain there.